### PR TITLE
Remove devtools from production

### DIFF
--- a/src/configureStore.dev.js
+++ b/src/configureStore.dev.js
@@ -1,0 +1,16 @@
+import {combineReducers, compose, createStore, applyMiddleware} from 'redux'
+import thunkMiddleware from 'redux-thunk'
+import createLogger from 'redux-logger'
+import * as reducers from './reducers'
+
+const loggerMiddleware = createLogger()
+
+const createStoreWithMiddleware = compose(
+  applyMiddleware(thunkMiddleware),
+  applyMiddleware(loggerMiddleware),
+  typeof window === 'object' && typeof window.devToolsExtension !== undefined ? window.devToolsExtension() : (f) => f
+)(createStore)
+
+export default function configureStore () {
+  return createStoreWithMiddleware(combineReducers(reducers))
+}

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -1,16 +1,5 @@
-import {combineReducers, compose, createStore, applyMiddleware} from 'redux'
-import thunkMiddleware from 'redux-thunk'
-import createLogger from 'redux-logger'
-import * as reducers from './reducers'
-
-const loggerMiddleware = createLogger()
-
-const createStoreWithMiddleware = compose(
-  applyMiddleware(thunkMiddleware),
-  applyMiddleware(loggerMiddleware),
-  typeof window === 'object' && typeof window.devToolsExtension !== undefined ? window.devToolsExtension() : (f) => f
-)(createStore)
-
-export default function configureStore () {
-  return createStoreWithMiddleware(combineReducers(reducers))
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./configureStore.prod')
+} else {
+  module.exports = require('./configureStore.dev')
 }

--- a/src/configureStore.prod.js
+++ b/src/configureStore.prod.js
@@ -1,0 +1,6 @@
+import {combineReducers, createStore} from 'redux'
+import * as reducers from './reducers'
+
+export default function configureStore () {
+  return createStore(combineReducers(reducers))
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-var path = require('path')
-var webpack = require('webpack')
+const path = require('path')
+const webpack = require('webpack')
 
 module.exports = {
   devtool: 'eval',
@@ -12,6 +12,10 @@ module.exports = {
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env.VERSION': JSON.stringify(require('./package.json')).version,
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    }),
     new webpack.NoErrorsPlugin()
   ],
   resolve: {


### PR DESCRIPTION
envify build script by passing in variables using the DefinePlugin
(details:
https://github.com/webpack/docs/wiki/list-of-plugins#defineplugin)
