### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/leifg/formulon-frontend/security/code-scanning/1](https://github.com/leifg/formulon-frontend/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since the workflow only involves checking out the code, setting up Node.js, and running commands like `yarn install`, `yarn lint`, and `yarn test`, it only needs `contents: read` permissions. This ensures the workflow has the least privilege necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
